### PR TITLE
Added Vue Router as well as removed memory leak of socket io events

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
     "test": "karma start build/karma.conf.js --single-run"
   },
   "dependencies": {
-    "vue": "^1.0.16"
+    "vue": "^1.0.16",
+    "vue-router": "^0.7.13",
+    "vuex-router-sync": "^1.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,18 +1,20 @@
 <template>
   <div id="app">
     <img class="logo" src="./assets/logo.png">
-    <Hello></Hello>
-    <Messages></Messages>
+    <p>
+      <a v-link="{ path: '/index' }">Go to Home</a>
+      <a v-link="{ path: '/messages' }">Go to Messages</a>
+    </p>
+    <router-view></router-view>
   </div>
 </template>
 
 <script>
-import Hello from './components/Hello'
-import Messages from './components/Messages'
-
-export default {
-  components: { Messages, Hello }
-}
+  import store from './vuex/store'
+  export default {
+    replace: false,
+    store
+  }
 </script>
 
 <style>

--- a/client/src/components/Messages.vue
+++ b/client/src/components/Messages.vue
@@ -14,9 +14,10 @@
 <script>
   import * as services from '../services'
   import { getMessages } from '../vuex/getters'
-  import { fetchMessages, addMessage, removeMessage } from '../vuex/actions'
+  import { fetchMessages, addMessage, removeMessage, stopAddMessageListener, stopRemoveMessageListener } from '../vuex/actions'
 
   export default {
+    name: 'messages',
     vuex: {
       getters: {
         messages: getMessages
@@ -37,6 +38,10 @@
       this.fetchMessages()
       this.addMessage()
       this.removeMessage()
+    },
+    beforeDestroy () {
+      stopAddMessageListener()
+      stopRemoveMessageListener()
     },
 
     methods: {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,15 +1,12 @@
 import Vue from 'vue'
-import Vuex from 'vuex'
 import App from './App'
+import { sync } from 'vuex-router-sync'
 
 import store from './vuex/store'
+import router from './router/index'
+// for debugging
+Vue.config.debug = true
 
-Vue.use(Vuex)
+sync(store, router)
 
-/* eslint-disable no-new */
-new Vue({
-  el: 'body',
-  store,
-  components: { App }
-})
-
+router.start(App, 'body')

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -1,0 +1,20 @@
+
+import VueRouter from 'vue-router'
+import Vue from 'vue'
+import Index from '../components/Hello'
+import Messages from '../components/Messages'
+
+Vue.use(VueRouter)
+
+var router = new VueRouter()
+
+router.map({
+  '/index': {
+    component: Index
+  },
+  '/messages': {
+    component: Messages
+  }
+})
+
+export default router

--- a/client/src/vuex/actions.js
+++ b/client/src/vuex/actions.js
@@ -6,17 +6,24 @@ export const fetchMessages = function ({dispatch}) {
     dispatch('FETCH_MESSAGES', messages.data)
   })
 }
-
+// Listener Object, held in local scope to remove later on component unmount
+let addListener = null
+let removeListener = null
 export const addMessage = function ({dispatch}) {
   // A new message has been created on the server, so dispatch a mutation to update our state/view
-  services.messageService.on('created', message => {
-    dispatch('ADD_MESSAGE', message)
-  })
+  addListener = (message) => { dispatch('ADD_MESSAGE', message) }
+  services.messageService.on('created', addListener)
 }
-
 export const removeMessage = function ({dispatch}) {
   // A message has been removed from the server, so dispatch a mutation to update our state/view
-  services.messageService.on('removed', message => {
-    dispatch('REMOVE_MESSAGE', message)
-  })
+  removeListener = (message) => { dispatch('REMOVE_MESSAGE', message) }
+  services.messageService.on('removed', removeListener)
+}
+export const stopAddMessageListener = function () {
+  // Stop listening to add messages
+  // Prevents memory leak and duplicate messages because a new addMessage listener will be created when the component remounts (hot reload, navigation)
+  services.messageService.off('created', addListener)
+}
+export const stopRemoveMessageListener = function () {
+  services.messageService.off('removed', removeListener)
 }


### PR DESCRIPTION
The actions addMessage and removeMessage create event functions that
never get removed.  In other words if a route changes or a hot reload
occurs (component reloads) then new addMessage listeners and
removeMessage listeners will be created; and the previous ones are not
removed. This leads to a memory leak as well as duplicate messages being
stored in the state.  This causes issues with rendering as well for the
v-for list.
